### PR TITLE
Improve accuracy and coverage of grammar

### DIFF
--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -37,28 +37,28 @@ patterns: [
           name: "punctuation.delimiter.semicolon.dircolors"
       }
       {
-          match: "^(\\s*)(TERM)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
+          match: "(?i)^(\\s*)(TERM)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
           captures:
               1: name: "punctuation.whitespace.comment.leading.dircolors"
               2: name: "keyword.other.dircolors"
               3: name: "variable.parameter.function.terminal-type.dircolors"
       }
       {
-          match: "^(\\s*)(COLOR|EIGHTBIT)\\s+(all|none|no|tty|yes)\\b"
+          match: "(?i)^(\\s*)(COLOR|EIGHTBIT)\\s+(all|none|no|tty|yes)\\b"
           captures:
               1: name: "punctuation.whitespace.comment.leading.dircolors"
               2: name: "keyword.other.dircolors"
               3: name: "constant.language.${3:/downcase}.dircolors"
       }
       {
-          match: "^(\\s*)(OPTIONS)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
+          match: "(?i)^(\\s*)(OPTIONS)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
           captures:
               1: name: "punctuation.whitespace.comment.leading.dircolors"
               2: name: "keyword.other.dircolors"
               3: patterns: [include: "source.opts"]
       }
       {
-          match: """(?x)
+          match: """(?ix)
               ^ (\\s*)
               (TERM|COLOR|EIGHTBIT|OPTION|NORMAL|NORM|FILE|RESET|DIR|LNK|LINK|SYMLINK|ORPHAN|MISSING
               |FIFO|PIPE|SOCK|BLK|BLOCK|CHR|CHAR|DOOR|EXEC|LEFT|LEFTCODE|RIGHT|RIGHTCODE|END|ENDCODE
@@ -100,6 +100,6 @@ repository:
             }
             {
                 name: "constant.character.escape.dircolors"
-                match: "\\\\[abefnrtv?\\_^#]"
+                match: "(?i)\\\\[abefnrtv?\\_^#]"
             }
         ]

--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -1,6 +1,11 @@
 scopeName: 'source.dircolors'
 name: 'dircolors'
-fileTypes: [ 'dircolors' ]
+fileTypes: [
+    "dircolors"
+    "dir_colors"
+    "_dir_colors"
+    "_dircolors"
+]
 patterns: [
       {
         begin: '(^\\s+)?(?<!\\S)(?=#)(?!#\\{)'

--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -28,7 +28,22 @@ patterns: [
           name: "constant.numeric.dircolors"
       }
       {
-          match: "\\b(TERM|COLOR|EIGHTBIT|OPTION|NORMAL|NORM|FILE|RESET|DIR|LNK|LINK|SYMLINK|ORPHAN|MISSING|FIFO|PIPE|SOCK|BLK|BLOCK|CHR|CHAR|DOOR|EXEC|LEFT|LEFTCODE|RIGHT|RIGHTCODE|END|ENDCODE|SUID|SETUID|SGID|SETGID|STICKY|OTHER_WRITABLE|OWR|STICKY_OTHER_WRITABLE|OWT|CAPABILITY|MULTIHARDLINK|CLRTOEOL)\\b"
-          name: "keyword.other.dircolors"
+          match: """(?x)
+              ^ (\\s*)
+              (TERM|COLOR|EIGHTBIT|OPTION|NORMAL|NORM|FILE|RESET|DIR|LNK|LINK|SYMLINK|ORPHAN|MISSING
+              |FIFO|PIPE|SOCK|BLK|BLOCK|CHR|CHAR|DOOR|EXEC|LEFT|LEFTCODE|RIGHT|RIGHTCODE|END|ENDCODE
+              |SUID|SETUID|SGID|SETGID|STICKY|OTHER_WRITABLE|OWR|STICKY_OTHER_WRITABLE|OWT|CAPABILITY
+              |MULTIHARDLINK|CLRTOEOL)
+              (?=\\s|\\#|$)
+          """
+          captures:
+              1: name: "punctuation.whitespace.comment.leading.dircolors"
+              2: name: "keyword.other.dircolors"
+      }
+      {
+          match: "^(\\s*)([^\\s#]+)"
+          captures:
+              1: name: "punctuation.whitespace.comment.leading.dircolors"
+              2: name: "keyword.other.extension.dircolors"
       }
   ]

--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -45,9 +45,35 @@ patterns: [
               2: name: "keyword.other.dircolors"
       }
       {
-          match: "^(\\s*)([^\\s#]+)"
+          match: "^(\\s*)((?:[^\\s#\\\\]|\\\\.)+)"
           captures:
-              1: name: "punctuation.whitespace.comment.leading.dircolors"
-              2: name: "keyword.other.extension.dircolors"
+              1:
+                name: "punctuation.whitespace.comment.leading.dircolors"
+              2:
+                name: "keyword.other.extension.dircolors"
+                patterns: [include: "#escape"]
+      }
+      {
+          include: "#escape"
       }
   ]
+repository:
+    escape:
+        patterns: [
+            {
+                name: "constant.character.escape.caret-notation.dircolors"
+                match: "\\^[?@A-Za-z\\[\\\\\\]^_]"
+            }
+            {
+                name: "constant.character.escape.codepoint.hexadecimal.dircolors"
+                match: "\\\\x[0-9A-Fa-f]{1,3}"
+            }
+            {
+                name: "constant.character.escape.codepoint.octal.dircolors"
+                match: "\\\\[0-7]{1,3}"
+            }
+            {
+                name: "constant.character.escape.dircolors"
+                match: "\\\\[abefnrtv?\\_^#]"
+            }
+        ]

--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -28,6 +28,10 @@ patterns: [
           name: "constant.numeric.dircolors"
       }
       {
+          match: ";"
+          name: "punctuation.delimiter.semicolon.dircolors"
+      }
+      {
           match: """(?x)
               ^ (\\s*)
               (TERM|COLOR|EIGHTBIT|OPTION|NORMAL|NORM|FILE|RESET|DIR|LNK|LINK|SYMLINK|ORPHAN|MISSING

--- a/grammars/dircolors.cson
+++ b/grammars/dircolors.cson
@@ -37,6 +37,27 @@ patterns: [
           name: "punctuation.delimiter.semicolon.dircolors"
       }
       {
+          match: "^(\\s*)(TERM)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
+          captures:
+              1: name: "punctuation.whitespace.comment.leading.dircolors"
+              2: name: "keyword.other.dircolors"
+              3: name: "variable.parameter.function.terminal-type.dircolors"
+      }
+      {
+          match: "^(\\s*)(COLOR|EIGHTBIT)\\s+(all|none|no|tty|yes)\\b"
+          captures:
+              1: name: "punctuation.whitespace.comment.leading.dircolors"
+              2: name: "keyword.other.dircolors"
+              3: name: "constant.language.${3:/downcase}.dircolors"
+      }
+      {
+          match: "^(\\s*)(OPTIONS)\\s+((?:[^\\s#\\\\]|\\\\.)+)"
+          captures:
+              1: name: "punctuation.whitespace.comment.leading.dircolors"
+              2: name: "keyword.other.dircolors"
+              3: patterns: [include: "source.opts"]
+      }
+      {
           match: """(?x)
               ^ (\\s*)
               (TERM|COLOR|EIGHTBIT|OPTION|NORMAL|NORM|FILE|RESET|DIR|LNK|LINK|SYMLINK|ORPHAN|MISSING


### PR DESCRIPTION
This PR is a mishmash of various enhancements that are missing from the current grammar:

* Lines beginning with file extensions weren't highlighted
* Keywords are matched case-sensitively (the [man page](https://linux.die.net/man/5/dir_colors) says that *"case is insignificant"*)
* Escape sequences like `\a` or `^@` weren't being highlighted
* Arguments of `TERM` lines weren't receiving highlighting (along with lesser-used statements like `EIGHTBIT`, `OPTIONS`, etc)

In addition, I've also added various spelling variations to the supported `fileTypes` array.

/cc @ObserverOfTime